### PR TITLE
Added package file

### DIFF
--- a/deimos/ncurses/package.d
+++ b/deimos/ncurses/package.d
@@ -1,0 +1,3 @@
+module deimos.ncurses;
+
+public import deimos.ncurses.ncurses;

--- a/examples/helloWorld.d
+++ b/examples/helloWorld.d
@@ -13,7 +13,7 @@
  * Modified by: 1100110
  */
 import std.string:  toStringz;
-import deimos.ncurses.ncurses;
+import deimos.ncurses;
 
 void main()
 {   //toStringz returns immutable char*   Which is what most of these


### PR DESCRIPTION
Allows to 'import deimos.ncurses;' instead of 'import deimos.ncurses.ncurses;'

Is this good practice, or is it something to be avoided?
