### PR TITLE
Add missing "importPaths" field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "sourcePaths": [
                     "deimos"
     ],
+    "importPaths": [
+                    "."
+    ],
     "libs": [
                     "ncursesw"
     ],


### PR DESCRIPTION
When using "ncurses" as a DUB dependency, the compiler was complaining than the `deimos.ncurses.*` modules couldn't be found, because the proper `-I` compiler switch was missing. This change fixes it.

A cleaner solution would be to move the "deimos/" directory into a separate "source/" folder, so that the .d files in the "examples/" folder are outside of the import path.
