### PR TITLE
Fix deprecation warning

### DIFF
--- a/deimos/ncurses/form.d
+++ b/deimos/ncurses/form.d
@@ -35,7 +35,7 @@
 module deimos.ncurses.form;
 
 
-import std.c.stdarg;
+import core.stdc.stdarg;
 public import deimos.ncurses.ncurses;
 public import deimos.ncurses.eti;
 


### PR DESCRIPTION
"deimos/ncurses/form.d(38,8): Deprecation: module std.c.stdarg is
deprecated - Import core.stdc.stdarg instead"