### PR TITLE
Fix building examples

### DIFF
--- a/examples/helloUnicode.d
+++ b/examples/helloUnicode.d
@@ -14,7 +14,7 @@
  * Modified by: Wyatt
  */
 import std.string:  toStringz;
-import std.c.locale;    // Need setlocale()
+import core.stdc.locale;    // Need setlocale()
 import deimos.ncurses.ncurses;
 
 void main()

--- a/examples/printw.d
+++ b/examples/printw.d
@@ -24,7 +24,7 @@ void main()
 	auto rowcol = "This screen has %d rows and %d columns\n".toStringz;
 	mvprintw(row-2, 0, rowcol, row+1, col+1);
 
-	printw(toStringz("Try resizing your window(if possible) and then run this program again"));
+	deimos.ncurses.ncurses.printw(toStringz("Try resizing your window(if possible) and then run this program again"));
 	refresh();
 
 	getch();


### PR DESCRIPTION
"helloUnicode.d(17): Deprecation: module std.c.locale is deprecated - Import core.stdc.locale instead"

"printw.d(27): Error: function expected before (), not module printw of type void"