### PR TITLE
Build with ncurses from Homebrew on macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 language: d
 
+os:
+  - linux
+  - osx
+
 d:
   - dmd
   - ldc
   - gdc
+
+matrix:
+  exclude:
+  - os: osx
+    d: gdc
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ncurses; fi
 
 script:
   - dub build

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ To use a specific configuration in your projects, depend on this package by addi
 }
 ```
 
+Building on macOS
+-----------------
+
+The stock ncurses libraries on macOS don't include the wide libraries. Thus the full ncurses version needs to be installed with [Homebrew](https://brew.sh/). Homebrew installs ncurses below ```/usr/local/opt/ncurses```, where the dub configuration will pick it up.
+
+First install Homebrew using the instructions on the web site, then you can add the ncurses package with
+
+````
+brew install ncurses
+````
+
 WARNINGS & PRECAUTIONS
 ----------------------
 What files make up the 'official' ncurses package?

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "license":      "ncurses",
     "targetType":   "staticLibrary",
     "targetName":   "ncurses-d",
+    "lflags-osx":   ["-L/usr/local/opt/ncurses/lib"],
     "configurations": [
         {
             "name": "minimal",


### PR DESCRIPTION
The stock ncurses on macOS doesn't come with the wide libraries which
are required to link this package.

This change also extends the Travis tests to run on macOS with dmd and ldc.

Travis build succeeded: https://travis-ci.org/jaydg/ncurses/builds/248691966