### PR TITLE
Add @nogc to all extern blocks

### DIFF
--- a/source/deimos/ncurses/curses.d
+++ b/source/deimos/ncurses/curses.d
@@ -925,8 +925,8 @@ int vid_attr(chtype a, ...)
  * These functions are extensions - not in X/Open Curses.
  */
  //TODO Check
-alias int function(WINDOW *, void *) NCURSES_WINDOW_CB;
-alias int function(SCREEN *, void *) NCURSES_SCREEN_CB;
+alias int function(WINDOW *, void *) @nogc NCURSES_WINDOW_NOGC_CB;
+alias int function(SCREEN *, void *) @nogc NCURSES_SCREEN_NOGC_CB;
 
 bool is_term_resized(int lines, int columns);
 char* keybound(int keycode, int count);
@@ -945,8 +945,8 @@ int use_default_colors();
 int use_extended_names(bool enable);
 int use_legacy_coding(int i);
 //TODO check, I might not have gotten the function pointer alias correct.
-int use_screen(SCREEN* scr, NCURSES_SCREEN_CB, void* v);
-int use_window(WINDOW* win, NCURSES_WINDOW_CB, void* v);
+int use_screen(SCREEN* scr, NCURSES_SCREEN_NOGC_CB, void* v);
+int use_window(WINDOW* win, NCURSES_WINDOW_NOGC_CB, void* v);
 int wresize(WINDOW* win, int lines, int columns);
 void nofilter();
 
@@ -1492,3 +1492,13 @@ body
 }
 
 }//end extern (C)
+
+// This block is for functions that can require some GC to work.
+extern (C) nothrow
+{
+alias int function(WINDOW *, void *) NCURSES_WINDOW_CB;
+alias int function(SCREEN *, void *) NCURSES_SCREEN_CB;
+
+int use_screen(SCREEN* scr, NCURSES_SCREEN_CB, void* v);
+int use_window(WINDOW* win, NCURSES_WINDOW_CB, void* v);
+}

--- a/source/deimos/ncurses/curses.d
+++ b/source/deimos/ncurses/curses.d
@@ -65,7 +65,7 @@ immutable enum
 /* This is defined in more than one ncurses header, for identification */
 string NCURSES_VERSION = "5.7";
 
-extern (C) nothrow
+extern (C) @nogc nothrow
 {
 
 /* types */

--- a/source/deimos/ncurses/curses.d
+++ b/source/deimos/ncurses/curses.d
@@ -925,8 +925,8 @@ int vid_attr(chtype a, ...)
  * These functions are extensions - not in X/Open Curses.
  */
  //TODO Check
-alias int function(WINDOW *, void *) @nogc NCURSES_WINDOW_NOGC_CB;
-alias int function(SCREEN *, void *) @nogc NCURSES_SCREEN_NOGC_CB;
+alias int function(WINDOW *, void *) NCURSES_WINDOW_CB;
+alias int function(SCREEN *, void *) NCURSES_SCREEN_CB;
 
 bool is_term_resized(int lines, int columns);
 char* keybound(int keycode, int count);
@@ -945,8 +945,8 @@ int use_default_colors();
 int use_extended_names(bool enable);
 int use_legacy_coding(int i);
 //TODO check, I might not have gotten the function pointer alias correct.
-int use_screen(SCREEN* scr, NCURSES_SCREEN_NOGC_CB, void* v);
-int use_window(WINDOW* win, NCURSES_WINDOW_NOGC_CB, void* v);
+int use_screen(SCREEN* scr, NCURSES_SCREEN_CB, void* v);
+int use_window(WINDOW* win, NCURSES_WINDOW_CB, void* v);
 int wresize(WINDOW* win, int lines, int columns);
 void nofilter();
 
@@ -1492,13 +1492,3 @@ body
 }
 
 }//end extern (C)
-
-// This block is for functions that can require some GC to work.
-extern (C) nothrow
-{
-alias int function(WINDOW *, void *) NCURSES_WINDOW_CB;
-alias int function(SCREEN *, void *) NCURSES_SCREEN_CB;
-
-int use_screen(SCREEN* scr, NCURSES_SCREEN_CB, void* v);
-int use_window(WINDOW* win, NCURSES_WINDOW_CB, void* v);
-}

--- a/source/deimos/ncurses/curses.d
+++ b/source/deimos/ncurses/curses.d
@@ -925,8 +925,6 @@ int vid_attr(chtype a, ...)
  * These functions are extensions - not in X/Open Curses.
  */
  //TODO Check
-alias int function(WINDOW *, void *) NCURSES_WINDOW_CB;
-alias int function(SCREEN *, void *) NCURSES_SCREEN_CB;
 
 bool is_term_resized(int lines, int columns);
 char* keybound(int keycode, int count);
@@ -1492,3 +1490,12 @@ body
 }
 
 }//end extern (C)
+
+// Things where @nogc would be needlessly limiting.
+extern (C) nothrow
+{
+
+alias int function(WINDOW *, void *) NCURSES_WINDOW_CB;
+alias int function(SCREEN *, void *) NCURSES_SCREEN_CB;
+
+}

--- a/source/deimos/ncurses/form.d
+++ b/source/deimos/ncurses/form.d
@@ -39,7 +39,7 @@ import core.stdc.stdarg;
 public import deimos.ncurses.ncurses;
 public import deimos.ncurses.eti;
 
-extern(C)
+extern(C) @nogc
 {
 
 alias void* FIELD_CELL;

--- a/source/deimos/ncurses/menu.d
+++ b/source/deimos/ncurses/menu.d
@@ -35,7 +35,7 @@ module deimos.ncurses.menu;
 public import deimos.ncurses.curses,
 	      deimos.ncurses.eti;
 
-extern(C)
+extern(C) @nogc
 {
 
 alias int Menu_Options;

--- a/source/deimos/ncurses/panel.d
+++ b/source/deimos/ncurses/panel.d
@@ -38,7 +38,7 @@ module deimos.ncurses.panel;
 
 public import deimos.ncurses.curses;
 
-extern (C)
+extern (C) @nogc
 {
 
 struct PANEL

--- a/source/deimos/ncurses/unctrl.d
+++ b/source/deimos/ncurses/unctrl.d
@@ -45,7 +45,7 @@ module deimos.ncurses.unctrl;
 
 string NCURSES_VERSION = "5.7";
 alias uint chtype;
-extern (C) char* unctrl(chtype);
+extern (C) char* unctrl(chtype) @nogc;
 
 
 /* NCURSES_UNCTRL_H_incl */


### PR DESCRIPTION
A pretty trivial change, should allow to work with the library in `@nogc` code. A quick run through examples doesn't seem to indicate that it breaks anything. Please tell me if anything needs editing.