### PR TITLE
deimos.ncurses.curses: Fix alignment of cchar_t

### DIFF
--- a/source/deimos/ncurses/curses.d
+++ b/source/deimos/ncurses/curses.d
@@ -303,6 +303,7 @@ immutable int _NEWINDEX = -1;
  */
 immutable size_t CCHARW_MAX = 5;
 
+align(1)
 struct cchar_t
 {
   attr_t attr;


### PR DESCRIPTION
The size is wrong due to the default D alignment.