### PR TITLE
Update lflags for homebrew on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ versions "NCURSES_REENTRANT"
 
 ## Building on macOS
 
-The stock ncurses libraries on macOS don't include the wide libraries. Thus the full ncurses version needs to be installed with [Homebrew](https://brew.sh/). Homebrew installs ncurses below ```/usr/local/opt/ncurses```, where the dub configuration will pick it up.
+The stock ncurses libraries on macOS don't include the wide libraries. Thus the full ncurses version needs to be installed with [Homebrew](https://brew.sh/). Homebrew installs ncurses below ```/usr/local/opt/ncurses``` (macOS Intel) or ```/opt/homebrew/opt/ncurses``` (Apple Silicon), where the dub configuration will pick it up.
 
 First install Homebrew using the instructions on the web site, then you can add the ncurses package with
 

--- a/dub.sdl
+++ b/dub.sdl
@@ -11,7 +11,8 @@ targetType "sourceLibrary"  # .di files only
 targetName "ncurses-d"
 
 # Howebrew installs libncurses here:
-lflags "-L/usr/local/opt/ncurses/lib" platform="osx"
+lflags "-L/usr/local/opt/ncurses/lib" platform="osx-x86_64"
+lflags "-L/opt/homebrew/opt/ncurses/lib" platform="osx-aarch64"
 
 configuration "minimal" {
 	libs "ncursesw"


### PR DESCRIPTION
Homebrew changed the prefix on Apple Silicon machines. This change will look at the new prefix for the ncurses lib if we are building on an Apple Silicon machine. 